### PR TITLE
Fix: #C4 Secure Architecture Patterns - enemy of enemy

### DIFF
--- a/docs/the-top-10/c4-secure-architecture.md
+++ b/docs/the-top-10/c4-secure-architecture.md
@@ -21,7 +21,7 @@ There are design principles that lead to secure architectures:
 
 ## Implementation
 
-The mantra "Complexity is the enemy of enemy of security" can be seen throughout this implementation guidance.
+The mantra "Complexity is the enemy of security" can be seen throughout this implementation guidance.
 
 ### Design for Clarity and Transparency
 


### PR DESCRIPTION
Hi,

In line 24 - the mantra "Complexity is the enemy of enemy of security" is quoted. In other words: "complexity promotes security".
Unfortunately, this contradicts the rest of the intended content: the more complexity, the less security.
Correctly it should be "simplicity is the enemy of the enemy of security" or "Complexity is the enemy of enemy of hackers"...
Otherwise - to say it with a KISS: "Complexity is the enemy of security" 