### PR TITLE
fix: corrected url link

### DIFF
--- a/docs/archive/2024/the-top-10/c3-validate-input-and-handle-exceptions.md
+++ b/docs/archive/2024/the-top-10/c3-validate-input-and-handle-exceptions.md
@@ -133,7 +133,7 @@ If that is not possible then consider a series of validation defenses when proce
 - Input validation is a technique that provides security to certain forms of data, specific to certain attacks and cannot be reliably applied as a general security rule.
 - Input validation should not be used as the primary method of preventing [XSS](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html), [SQL Injection](https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet) and other attacks.
 - [2023 CWE Top 25 - 3 Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')](https://cwe.mitre.org/data/definitions/89.html)
-- [2023 CWE Top 25 - 5 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')](https://cwe.mitre.org/data/definitions/89.html)
+- [2023 CWE Top 25 - 5 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')](https://cwe.mitre.org/data/definitions/78.html)
 - [2023 CWE Top 25 - 16 Improper Neutralization of Special Elements used in a Command ('Command Injection')](https://cwe.mitre.org/data/definitions/77.html)
 - [2023 CWE Top 25 - 23 Improper Control of Generation of Code ('Code Injection')](https://cwe.mitre.org/data/definitions/94.html)
 


### PR DESCRIPTION
The link of "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')]" was the same of "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"